### PR TITLE
run3 flag determining LCT quality assignment instead of cclut flag

### DIFF
--- a/L1Trigger/CSCTriggerPrimitives/interface/CSCBaseboard.h
+++ b/L1Trigger/CSCTriggerPrimitives/interface/CSCBaseboard.h
@@ -108,6 +108,7 @@ protected:
   bool runME31Up_;
   bool runME41Up_;
 
+  bool run3_;
   bool runCCLUT_;
   bool runCCLUT_TMB_;
   bool runCCLUT_OTMB_;

--- a/L1Trigger/CSCTriggerPrimitives/interface/LCTQualityAssignment.h
+++ b/L1Trigger/CSCTriggerPrimitives/interface/LCTQualityAssignment.h
@@ -76,10 +76,10 @@ public:
   unsigned findQuality(const CSCCLCTDigi& cLCT, const GEMInternalCluster& cl) const;
 
 private:
-  // quality for all LCTs in Run-1 and Run-2 (CCLUT off)
+  // quality for all LCTs in Run-1 and Run-2 (run-3 mode off)
   unsigned findQualityRun2(const CSCALCTDigi& aLCT, const CSCCLCTDigi& cLCT) const;
 
-  // quality for non-ME1/1 LCTs in Run-3 without GEMs (CCLUT on)
+  // quality for non-ME1/1 LCTs in Run-3 without GEMs (run-3 mode on)
   unsigned findQualityRun3(const CSCALCTDigi& aLCT, const CSCCLCTDigi& cLCT) const;
 
   // quality for LCTs in Run-3 with GEMs (CCLUT off)
@@ -87,7 +87,7 @@ private:
   unsigned findQualityGEMv1(const CSCCLCTDigi&, const GEMInternalCluster& cl) const;
   unsigned findQualityGEMv1(const CSCALCTDigi&, const CSCCLCTDigi&, const GEMInternalCluster& cl) const;
 
-  // quality for LCTs in Run-3 with GEMs (CCLUT on(
+  // quality for LCTs in Run-3 with GEMs (CCLUT on)
   unsigned findQualityGEMv2(const CSCALCTDigi&, const CSCCLCTDigi&, const GEMInternalCluster& cl) const;
 
   bool assignGEMCSCBending_;

--- a/L1Trigger/CSCTriggerPrimitives/python/params/auxiliaryParams.py
+++ b/L1Trigger/CSCTriggerPrimitives/python/params/auxiliaryParams.py
@@ -28,6 +28,9 @@ commonParam = cms.PSet(
     runME11ILT = cms.bool(False),
     runME21ILT = cms.bool(False),
 
+    # Run-3 mode
+    run3 = cms.bool(False),
+
     # comparator-code algorithm to improve
     # CLCT position and bending resolution
     # CCLUT for TMB is NOT planned for startup Run-3

--- a/L1Trigger/CSCTriggerPrimitives/src/CSCBaseboard.cc
+++ b/L1Trigger/CSCTriggerPrimitives/src/CSCBaseboard.cc
@@ -48,6 +48,7 @@ CSCBaseboard::CSCBaseboard(unsigned endcap,
   runME11ILT_ = commonParams_.getParameter<bool>("runME11ILT");
   runME21ILT_ = commonParams_.getParameter<bool>("runME21ILT");
 
+  run3_ = commonParams_.getParameter<bool>("run3");
   runCCLUT_TMB_ = commonParams_.getParameter<bool>("runCCLUT_TMB");
   runCCLUT_OTMB_ = commonParams_.getParameter<bool>("runCCLUT_OTMB");
   // check if CCLUT should be on in this chamber

--- a/L1Trigger/CSCTriggerPrimitives/src/LCTQualityAssignment.cc
+++ b/L1Trigger/CSCTriggerPrimitives/src/LCTQualityAssignment.cc
@@ -13,7 +13,7 @@ LCTQualityAssignment::LCTQualityAssignment(unsigned endcap,
 
 unsigned LCTQualityAssignment::findQuality(const CSCALCTDigi& aLCT, const CSCCLCTDigi& cLCT) const {
   // ALCT-CLCT matching without a cluster and ILT off
-  if (runCCLUT_ and !runILT_) {
+  if (run3_ and !runILT_) {
     return findQualityRun3(aLCT, cLCT);
   }
   // ALCT-CLCT matching without a cluster and ILT on

--- a/L1Trigger/CSCTriggerPrimitives/src/LCTQualityControl.cc
+++ b/L1Trigger/CSCTriggerPrimitives/src/LCTQualityControl.cc
@@ -488,8 +488,8 @@ std::pair<unsigned, unsigned> LCTQualityControl::get_csc_lct_min_max_quality(uns
 
   const bool GEMCSC = (isME11_ and runME11ILT_) or (isME21_ and runME21ILT_);
 
-  // Run-3 with CCLUT on
-  if (runCCLUT_ and !GEMCSC) {
+  // Run-3
+  if (run3_ and !GEMCSC) {
     min_quality = static_cast<unsigned>(LCTQualityAssignment::LCT_QualityRun3::LowQ);
     max_quality = static_cast<unsigned>(LCTQualityAssignment::LCT_QualityRun3::HighQ);
   }

--- a/L1Trigger/CSCTriggerPrimitives/test/runCSCTriggerPrimitiveProducer_cfg.py
+++ b/L1Trigger/CSCTriggerPrimitives/test/runCSCTriggerPrimitiveProducer_cfg.py
@@ -32,7 +32,7 @@ options.register("useB904ME21", False, VarParsing.multiplicity.singleton, VarPar
                  "Set to True when using B904 ME2/1 data (also works for ME3/1 and ME4/1).")
 options.register("useB904ME234s2", False, VarParsing.multiplicity.singleton, VarParsing.varType.bool,
                  "Set to True when using B904 ME1/1 data (also works for MEX/2 and ME1/3).")
-options.register("run3", True, VarParsing.multiplicity.singleton, VarParsing.varType.bool,
+options.register("run3", False, VarParsing.multiplicity.singleton, VarParsing.varType.bool,
                  "Set to True when using Run-3 data.")
 options.register("runCCLUTOTMB", False, VarParsing.multiplicity.singleton, VarParsing.varType.bool,
                  "Set to True when using the CCLUT OTMB algorithm.")
@@ -124,6 +124,7 @@ if useB904Data:
 ## l1 emulator
 l1csc = process.cscTriggerPrimitiveDigis
 if options.l1:
+      l1csc.commonParam.run3 = cms.bool(options.run3)
       l1csc.commonParam.runCCLUT_OTMB = cms.bool(options.runCCLUTOTMB)
       l1csc.commonParam.runCCLUT_TMB = cms.bool(options.runCCLUTTMB)
       l1csc.commonParam.runME11ILT = options.runME11ILT


### PR DESCRIPTION
-> Aligning to CSC old TMB firmware with new run3 trigger data format 
implemented. CCLUTs will not be implemented, but the LCT quality will be 
sent in run3 format

#### PR description:

<!-- Please replace this text with a description of the feature proposed or problem addressed, specifying:
  - what changes are expected in the output if any, 
  - what other PRs or externals it depends upon if any,
  - link to any additional material useful to provide a documentation for this PR (slides, JIRA tickets, related pull requestes, hypernews, TWiki or Indico pages)  -->

#### PR validation:

<!-- Please replace this text with a description of which tests have been performed to verify the correctness of the PR, including the eventual addition of new code for testing like unit tests, test configurations, additions or updates to the runTheMatrix test workflows -->

#### if this PR is a backport please specify the original PR and why you need to backport that PR:

<!-- Please replace this text with any link to  -->

Before submitting your pull requests, make sure you followed this checklist:
- verify that the PR is really intended for the chosen branch
- verify that changes follow [CMS Naming, Coding, And Style Rules](http://cms-sw.github.io/cms_coding_rules.html)
- verify that the PR passes the basic test procedure suggested in the [CMSSW PR instructions](https://cms-sw.github.io/PRWorkflow.html)
